### PR TITLE
Enable docs publication on `main`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,9 +44,7 @@ jobs:
 
   pages:
     runs-on: ubuntu-latest
-    if: false
-    # disable til moved to conda-incubator
-    # github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     needs: [docs]
 
     # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages


### PR DESCRIPTION
Now that we are in conda-incubator, let's publish to GH Pages