### PR TITLE
Add text showing how to use the served channel

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: "Name of the subchannel that will be created"
     required: false
     default: "subchannel"
+  served-at:
+    description: "URL where the subchannel files will be uploaded to"
+    required: false
+    default: ""
   channel:
     description: "Source conda channel"
     required: true
@@ -99,9 +103,12 @@ runs:
             "--repodata-fn",
             """${{ inputs.repodata-fn }}""".strip(),
         ]
+        served_at = """${{ inputs.served-at }}""".strip()
+        if served_at:
+            args += ["--served-at", served_at]
         base_url = """${{ inputs.base-url }}""".strip()
         if base_url:
-            args += ["--base_url", base_url]
+            args += ["--base-url", base_url]
         after = """${{ inputs.after }}""".strip()
         if after:
             args += ["--after", after]

--- a/conda_subchannel/cli.py
+++ b/conda_subchannel/cli.py
@@ -53,13 +53,19 @@ def configure_parser(parser: argparse.ArgumentParser):
         required=False,
         help="URL where the packages will be available. "
         "Defaults to the base URL for '--channel'. Only needed if the user wants to mirror "
-        "the required packages separately."
+        "the required packages separately.",
     )
     parser.add_argument(
         "--output",
         default="subchannel",
         metavar="PATH",
         help="Directory where the subchannel repodata.json artifacts will be written to.",
+    )
+    parser.add_argument(
+        "--served-at",
+        metavar="URL",
+        help="URL or location where the subchannel files will be eventually served. "
+        "Used for the HTML output.",
     )
     parser.add_argument(
         "--subdir",
@@ -123,7 +129,6 @@ def execute(args: argparse.Namespace) -> int:
         "before": args.before,
     }
     with Spinner("Filtering package records"):
-
         records = _reduce_index(**kwargs)
     total_count = sum(len(sd._package_records) for sd in subdir_datas)
     filtered_count = len(records)
@@ -136,6 +141,12 @@ def execute(args: argparse.Namespace) -> int:
         base_url = args.base_url or Channel(args.channel).base_url
         repodatas = _dump_records(records, base_url)
         kwargs.pop("subdir_datas")
-        _write_to_disk(args.channel, repodatas, args.output, cli_flags=kwargs)
+        _write_to_disk(
+            args.channel,
+            repodatas,
+            args.output,
+            cli_flags=kwargs,
+            served_at=args.served_at,
+        )
 
     return 0

--- a/conda_subchannel/core.py
+++ b/conda_subchannel/core.py
@@ -192,7 +192,7 @@ def _checksum(path, algorithm, buffersize=65536):
     return hash_impl.hexdigest()
 
 
-def _write_channel_index_html(source_channel: Channel, channel_path: Path, cli_flags: dict[str, Any]):
+def _write_channel_index_html(source_channel: Channel, channel_path: Path, cli_flags: dict[str, Any], served_at: str | None = None):
     templates_dir = Path(__file__).parent / "templates"
     environment = jinja2.Environment(loader=jinja2.FileSystemLoader(templates_dir))
     template = environment.get_template("channel.j2.html")
@@ -203,6 +203,7 @@ def _write_channel_index_html(source_channel: Channel, channel_path: Path, cli_f
         source_channel_name=source_channel.name,
         subdirs=[path.name for path in channel_path.glob("*") if path.is_dir()],
         cli_flags=cli_flags,
+        subchannel_url=served_at or "",
     )
     (channel_path / "index.html").write_text(content)
     (channel_path / "style.css").write_text((templates_dir / "style.css").read_text())
@@ -255,6 +256,7 @@ def _write_to_disk(
     repodatas: dict[str, dict[str, Any]],
     path: os.PathLike | str,
     cli_flags: dict[str, Any],
+    served_at: str | None = None,
     outputs: Iterable[str] = ("bz2", "zstd"),
 ):
     path = Path(path)
@@ -284,7 +286,7 @@ def _write_to_disk(
         noarch_repodata.write_text("{}")
         _write_subdir_index_html(path / "noarch")
 
-    _write_channel_index_html(Channel(source_channel), path, cli_flags)
+    _write_channel_index_html(Channel(source_channel), path, cli_flags, served_at)
 
 
 def _sortkey_package_filenames(fn: str):

--- a/conda_subchannel/templates/channel.j2.html
+++ b/conda_subchannel/templates/channel.j2.html
@@ -34,6 +34,17 @@
         <li><a href="{{ subdir }}">{{ subdir }}</a></li>
         {% endfor %}
       </ul>
+
+      <p>You can use this subchannel with the URL <code id="channel-url">{{ subchannel_url }}</code></p>
+      <p>For example, with <code>conda</code>:</p>
+      <pre>
+        <code>$ conda create -n new-channel --override-channel -c <span id="channel-url">{{ subchannel_url }}</span></code>
+      </pre>
     </div>
+    {% if not subchannel_url %}
+    <script type="text/javascript">
+      document.querySelectorAll("#channel-url").forEach((elem => elem.innerText = window.location));
+    </script>
+    {% endif %}
   </body>
 </html>

--- a/tests/test_subchannel.py
+++ b/tests/test_subchannel.py
@@ -212,6 +212,7 @@ def test_between_dates(conda_cli, tmp_path):
             )
     assert tested
 
+
 def test_base_url(conda_cli, tmp_path):
     base_url = "https://a-redefined-base.url"
     out, err, rc = conda_cli(
@@ -231,3 +232,24 @@ def test_base_url(conda_cli, tmp_path):
 
     data = json.loads((tmp_path / context.subdir / "repodata.json").read_text())
     assert data["info"]["base_url"] == base_url
+
+
+def test_served_at(conda_cli, tmp_path):
+    served_at = "https://my-fancy-channel.url"
+    out, err, rc = conda_cli(
+        "subchannel",
+        "-c",
+        "conda-forge",
+        "--keep",
+        "python=3.9",
+        "--served-at",
+        served_at,
+        "--output",
+        tmp_path,
+    )
+    print(out)
+    print(err, file=sys.stderr)
+    assert rc == 0
+
+    for path in tmp_path.glob("**/index.html"):
+        assert served_at in path.read_text()


### PR DESCRIPTION
Adds `--served-at` CLI option to mention the target URL explicitly. Would allow for uploading files somewhere else than the HTML pages.