### PR TITLE
Add a `--prune` flag to just filter packages within a name

### DIFF
--- a/conda_subchannel/cli.py
+++ b/conda_subchannel/cli.py
@@ -101,6 +101,12 @@ def configure_parser(parser: argparse.ArgumentParser):
         help="Keep packages matching this spec only. Can be used several times.",
     )
     parser.add_argument(
+        "--prune",
+        metavar="SPEC",
+        action="append",
+        help="Remove the distributions of this package name that do not match this spec.",
+    )
+    parser.add_argument(
         "--remove",
         metavar="SPEC",
         action="append",
@@ -109,7 +115,7 @@ def configure_parser(parser: argparse.ArgumentParser):
 
 
 def execute(args: argparse.Namespace) -> int:
-    if not any([args.after, args.before, args.keep, args.remove, args.keep_tree]):
+    if not any([args.after, args.before, args.keep, args.remove, args.keep_tree, args.prune]):
         raise ArgumentError("Please provide at least one filter.")
 
     with Spinner("Syncing source channel"):
@@ -124,6 +130,7 @@ def execute(args: argparse.Namespace) -> int:
         "subdir_datas": subdir_datas,
         "specs_to_keep": args.keep,
         "specs_to_remove": args.remove,
+        "specs_to_prune": args.prune,
         "trees_to_keep": args.keep_tree,
         "after": args.after,
         "before": args.before,

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,5 +1,7 @@
 # Usage
 
+## CLI
+
 ```
 $ conda subchannel --help
 usage: conda subchannel -c CHANNEL [--repodata-fn REPODATA_FN] [--base-url BASE_URL] [--output PATH] [--subdir PLATFORM] [--after TIME] [--before TIME] [--keep-tree SPEC] [--keep SPEC] [--remove SPEC] [-h]
@@ -22,6 +24,23 @@ options:
   --keep-tree SPEC      Keep packages matching this spec and their dependencies. Can be used
                         several times.
   --keep SPEC           Keep packages matching this spec only. Can be used several times.
+  --prune SPEC          Remove the distributions of this package name that do not match the
+                        given constraints.
   --remove SPEC         Remove packages matching this spec. Can be used several times.
   -h, --help            Show this help message and exit.
   ```
+
+
+## Filtering algorithm
+
+The filtering algorithm operates in two phases: selection
+
+In the first phase, we _select_ which records are going to be kept. Everything else is removed.
+
+1. A selection list is built. Records in this list are added if:
+  - They match specs in `--keep-tree`, or any of the dependencies in their tree (assessed recursively).
+  - They match any of the specs in `--keep`.
+  - Their timestamp is within the limits marked by `--before` and `--after`, when applicable. 
+2. At this point, records that didn't make it to the selection list are removed.
+3. The specs defined `--prune` are processed. Records that have the same name but don't match the spec are removed. Everything else is ignored.
+4. Records matching any of the specs in `--remove` are filtered out.


### PR DESCRIPTION
Adds:

```
  --prune SPEC          Remove the distributions of this package name that do not match the
                        given constraints.
```

This allows a channel to be created by trimming a package to the required versions only, but leaving the rest of the channel alone. So, if you just want to use python=3.10 in your channel, instead of having to do

```
... --remove python=3.8 --remove python=3.9 --remove python=3.11 ...
```

You can do now:

```
... --prune python=3.10
```